### PR TITLE
Store glucose records with the device's zone offset, not UTC

### DIFF
--- a/app/src/main/java/org/c99/healthconnect_librelinkup/SyncWorker.java
+++ b/app/src/main/java/org/c99/healthconnect_librelinkup/SyncWorker.java
@@ -82,8 +82,13 @@ public class SyncWorker extends Worker {
             ZonedDateTime time;
             if (gm.FactoryTimestamp != null) {
                 try {
-                    // Attempt to parse as a datetime string
-                    time = ZonedDateTime.parse((String) gm.FactoryTimestamp + " +0000", DateTimeFormatter.ofPattern("M/d/y h:m:s a Z"));
+                    // Attempt to parse as a datetime string. FactoryTimestamp is in UTC,
+                    // so re-express it in the device's zone with withZoneSameInstant: this
+                    // keeps the same instant but stores the correct local offset. The record
+                    // below uses time.getOffset() for the reading's local date/time, so a
+                    // hardcoded +0000 pushes evening readings past the UTC date boundary onto
+                    // the following day (e.g. after 19:00 for a UTC-5 user).
+                    time = ZonedDateTime.parse((String) gm.FactoryTimestamp + " +0000", DateTimeFormatter.ofPattern("M/d/y h:m:s a Z")).withZoneSameInstant(ZoneId.systemDefault());
                 } catch (DateTimeParseException e) {
                     // If parsing fails, assume it's a long timestamp
                     try {


### PR DESCRIPTION
### Problem
`SyncWorker` builds each `BloodGlucoseRecord` with `time.getOffset()` as the zone offset, but `time` is parsed from the UTC `FactoryTimestamp` with a hardcoded `" +0000"`. Every record is therefore stored with a `+00:00` offset regardless of the user's timezone.

Health Connect uses a record's stored offset to position it on the local date/time axis. For any user behind UTC, readings taken after `24:00 - |offset|` local fall on the next UTC date and get filed under the following calendar day, at a clock time that hasn't happened yet. For a user at UTC-5: readings stop appearing under **Today** at 19:00 local, and at local midnight a run of entries appears dated to the new day at 19:00-24:00 (future times).

### Fix
Re-express the parsed UTC time in the device's own zone with `withZoneSameInstant(ZoneId.systemDefault())`. `Instant.from(time)` is unchanged (same instant), while `time.getOffset()` becomes the device's real offset. This mirrors the existing numeric-timestamp fallback path just below it, and is DST-safe because the offset is resolved at the reading's instant. One line; `ZoneId` is already imported.

The Wear tile and complication are unaffected. The tile derives its "N minutes ago" label from `time.toEpochSecond()`, which is offset-independent.